### PR TITLE
1.1.0-beta

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,9 +4,7 @@ module.exports = {
 		sourceType: 'module',
 		ecmaVersion: 2019
 	},
-	extends: [
-		'plugin:@typescript-eslint/recommended'
-	],
+	extends: ['plugin:@typescript-eslint/recommended'],
 	rules: {
 		'@typescript-eslint/camelcase': 0,
 		'@typescript-eslint/explicit-function-return-type': 0,
@@ -16,25 +14,22 @@ module.exports = {
 		'@typescript-eslint/no-unused-vars': [
 			2,
 			{
-				'vars': 'all',
-				'args': 'none',
-				'caughtErrors': 'all'
+				vars: 'all',
+				args: 'none',
+				caughtErrors: 'all'
 			}
 		],
-		'indent': [
-			'error',
+		indent: [
+			2,
 			'tab',
 			{
-				'SwitchCase': 1
+				SwitchCase: 1
 			}
 		],
 		'no-extra-boolean-cast': 0,
 		'no-sequences': 2,
 		'no-tabs': 0,
 		'no-unused-vars': 0,
-		'semi': [
-			'error',
-			'always'
-		]
+		semi: [2, 'always']
 	}
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,14 +12,44 @@ module.exports = {
 		'@typescript-eslint/naming-convention': [
 			2,
 			{
-				selector: 'memberLike',
-				format: ['camelCase']
-			},
-			{
-				selector: 'memberLike',
+				selector: 'property',
 				modifiers: ['private'],
 				format: ['camelCase'],
 				leadingUnderscore: 'require'
+			},
+			{
+				selector: 'parameterProperty',
+				format: ['camelCase']
+			},
+			{
+				selector: 'parameterProperty',
+				modifiers: ['private'],
+				format: ['camelCase'],
+				leadingUnderscore: 'require'
+			},
+			{
+				selector: 'method',
+				format: ['camelCase']
+			},
+			{
+				selector: 'method',
+				modifiers: ['private'],
+				format: ['camelCase'],
+				leadingUnderscore: 'require'
+			},
+			{
+				selector: 'accessor',
+				format: ['camelCase']
+			},
+			{
+				selector: 'accessor',
+				modifiers: ['private'],
+				format: ['camelCase'],
+				leadingUnderscore: 'require'
+			},
+			{
+				selector: 'enumMember',
+				format: ['PascalCase']
 			},
 			{
 				selector: 'variable',
@@ -27,42 +57,42 @@ module.exports = {
 			},
 			{
 				selector: 'function',
-				format: ['camelCase']
+				format: ['camelCase', 'PascalCase']
 			},
 			{
 				selector: 'parameter',
 				format: ['camelCase']
 			},
 			{
-				selector: 'typeParameter',
+				selector: 'class',
+				format: ['PascalCase']
+			},
+			{
+				selector: 'class',
+				modifiers: ['abstract'],
 				format: ['PascalCase'],
 				custom: {
-					regex: '^G[A-Z]',
+					regex: '^Abstract[A-Z]',
 					match: true
 				}
 			},
 			{
 				selector: 'interface',
 				format: ['PascalCase'],
-				custom: {
-					regex: '^I[A-Z]',
-					match: true
-				}
+				prefix: ['I']
 			},
 			{
 				selector: 'typeAlias',
 				format: ['PascalCase'],
-				custom: {
-					regex: '^T[A-Z]',
-					match: true
-				}
+				prefix: ['T']
+			},
+			{
+				selector: 'typeParameter',
+				format: ['PascalCase'],
+				prefix: ['G']
 			},
 			{
 				selector: 'enum',
-				format: ['PascalCase']
-			},
-			{
-				selector: 'enumMember',
 				format: ['PascalCase']
 			}
 		],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,64 @@ module.exports = {
 	rules: {
 		'@typescript-eslint/camelcase': 0,
 		'@typescript-eslint/explicit-function-return-type': 0,
+		'@typescript-eslint/explicit-module-boundary-types': 0,
+		'@typescript-eslint/naming-convention': [
+			2,
+			{
+				selector: 'memberLike',
+				format: ['camelCase']
+			},
+			{
+				selector: 'memberLike',
+				modifiers: ['private'],
+				format: ['camelCase'],
+				leadingUnderscore: 'require'
+			},
+			{
+				selector: 'variable',
+				format: ['camelCase', 'UPPER_CASE', 'PascalCase']
+			},
+			{
+				selector: 'function',
+				format: ['camelCase']
+			},
+			{
+				selector: 'parameter',
+				format: ['camelCase']
+			},
+			{
+				selector: 'typeParameter',
+				format: ['PascalCase'],
+				custom: {
+					regex: '^G[A-Z]',
+					match: true
+				}
+			},
+			{
+				selector: 'interface',
+				format: ['PascalCase'],
+				custom: {
+					regex: '^I[A-Z]',
+					match: true
+				}
+			},
+			{
+				selector: 'typeAlias',
+				format: ['PascalCase'],
+				custom: {
+					regex: '^T[A-Z]',
+					match: true
+				}
+			},
+			{
+				selector: 'enum',
+				format: ['PascalCase']
+			},
+			{
+				selector: 'enumMember',
+				format: ['PascalCase']
+			}
+		],
 		'@typescript-eslint/no-empty-interface': 0,
 		'@typescript-eslint/no-explicit-any': 0,
 		'@typescript-eslint/no-var-requires': 0,

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+package.json
+package-lock.json
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "eslint-config-wezom-relax-ts",
+  "version": "1.0.0-beta",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "prettier": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.1.tgz",
+      "integrity": "sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==",
+      "dev": true
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wezom-relax-ts",
-  "version": "1.0.0-beta",
+  "version": "1.1.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wezom-relax-ts",
-  "version": "1.0.0-beta",
+  "version": "1.1.0-beta",
   "description": "An ESLint shareable config for Typescript",
   "main": ".eslintrc.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -20,10 +20,23 @@
     "url": "https://github.com/WezomAgency/eslint-config-wezom-relax-ts/issues"
   },
   "homepage": "https://github.com/WezomAgency/eslint-config-wezom-relax-ts#readme",
+  "prettier": {
+    "arrowParens": "always",
+    "bracketSpacing": true,
+    "printWidth": 90,
+    "semi": true,
+    "singleQuote": true,
+    "trailingComma": "none",
+    "tabWidth": 4,
+    "useTabs": true
+  },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.0.1",
     "@typescript-eslint/parser": "^4.0.1",
     "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-import": "^2.22.0"
+  },
+  "devDependencies": {
+    "prettier": "^2.1.1"
   }
 }


### PR DESCRIPTION
- 025294c Add Prettier
- 144dfd0 Add new rules:
  - `@typescript-eslint/explicit-module-boundary-types`
  - `@typescript-eslint/naming-convention`
- 660d7ff Add options for `@typescript-eslint/naming-convention` rule
