### PR TITLE
1.2.1-beta

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -93,7 +93,11 @@ module.exports = {
 			},
 			{
 				selector: 'enum',
-				format: ['PascalCase']
+				format: ['PascalCase'],
+				custom: {
+					regex: '[a-z]List$',
+					match: true
+				}
 			}
 		],
 		'@typescript-eslint/no-empty-interface': 0,

--- a/README.md
+++ b/README.md
@@ -24,3 +24,8 @@ npm i -D eslint-config-wezom-relax-ts
 ```bash
 npm i -D @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-plugin-flowtype eslint-plugin-import
 ```
+
+## Rules
+
+ESLint configuration and list of rules can be viewed in the source file [.eslintrc.js file](https://github.com/WezomAgency/eslint-config-wezom-relax-ts/blob/master/.eslintrc.js).  
+Detailed description each of rule see on [`@typescript-eslint/typescript-eslint` docs](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin/docs).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wezom-relax-ts",
-  "version": "1.2.0-beta",
+  "version": "1.2.1-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wezom-relax-ts",
-  "version": "1.1.0-beta",
+  "version": "1.2.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "eslint-config-wezom-relax-ts",
-  "version": "1.1.0-beta",
+  "version": "1.2.0-beta",
   "description": "An ESLint shareable config for Typescript",
   "main": ".eslintrc.js",
   "files": [
     ".eslintrc.js"
   ],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prettier": ".eslintrc.js --check --write"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wezom-relax-ts",
-  "version": "1.2.0-beta",
+  "version": "1.2.1-beta",
   "description": "An ESLint shareable config for Typescript",
   "main": ".eslintrc.js",
   "files": [


### PR DESCRIPTION
- a61dc50 1.2.0-beta. Extend `@typescript-eslint/naming-convention` rule
- c08cbcd 1.2.1-beta. Update README description
